### PR TITLE
Fixed day 14 - part 2

### DIFF
--- a/Update/onik_014_02.txt
+++ b/Update/onik_014_02.txt
@@ -3326,9 +3326,9 @@ void main()
 
 //　レナは!s500............!sd両親が不在であることを!s500.........!sd知っている＠
 	OutputLine(NULL, "　レナは…………",
-		   NULL, "Rena...", Line_Normal);
+		   NULL, "Rena...", Line_WaitForInput);
 	OutputLine(NULL, "両親が不在であることを………",
-		   NULL, " Did she...", Line_Normal);
+		   NULL, " Did she...", Line_WaitForInput);
 	OutputLine(NULL, "知っている？",
 		   NULL, " Did she know that my parents weren't home?", Line_WaitForInput);
 	OutputLineAll(NULL, "\n\n", Line_ContinueAfterTyping);


### PR DESCRIPTION
`Line_Normal` is basically used just before `ClearMessage();` so I think it was a mistake in these cases.